### PR TITLE
Add Docker/SIF builds

### DIFF
--- a/.github/workflows/container_build.yml
+++ b/.github/workflows/container_build.yml
@@ -1,0 +1,76 @@
+name: ci container build
+
+on:
+  pull_request:
+    branches:
+      - 'main'
+  push:
+    branches:
+      - 'main'
+    tags:
+      - "v*.*.*"
+env:
+  LATEST_TAG: ghcr.io/${{ github.repository_owner }}/mix3r:latest
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ghcr.io/${{ github.repository_owner }}/mix3r            
+          tags: |
+            type=schedule
+            type=ref,event=branch
+            type=ref,event=pr
+            type=pep440,pattern={{version}}
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha
+            type=raw,value=latest,enable={{is_default_branch}} 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to GitHub Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # - name: Build and export to Docker
+      #   uses: docker/build-push-action@v6
+      #   with:
+      #     context: "{{defaultContext}}:docker"
+      #     load: true
+      #     tags: ${{ env.LATEST_TAG }}
+      #     file:
+      #       .Dockerfile
+      #     platforms: linux/amd64, linux/arm64
+
+      # - name: Run unit tests I
+      #   run: |
+      #     docker run --rm -v ${{ github.workspace }}:/home ${{ env.LATEST_TAG }} py.test -v tests
+      
+      # - name: Run unit tests II
+      #   run: |
+      #     pip install -r test-requirements.txt
+      #     py.test -v tests
+
+      - name: Build
+        uses: docker/build-push-action@v6
+        with:
+          context: "{{defaultContext}}"
+          push: False
+          load: True
+          tags: ${{ steps.meta.outputs.tags }}
+          file:
+            ./docker/Dockerfile
+          platforms: linux/amd64

--- a/.github/workflows/container_build_push.yml
+++ b/.github/workflows/container_build_push.yml
@@ -1,0 +1,115 @@
+name: ci container build-push
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+env:
+  LATEST_TAG: ghcr.io/${{ github.repository_owner }}/mix3r:latest
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          # list of Docker images to use as base name for tags
+          images: |
+            ghcr.io/${{ github.repository_owner }}/mix3r       
+          tags: |
+            type=schedule
+            type=ref,event=branch
+            type=ref,event=pr
+            type=pep440,pattern={{version}}
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha
+            type=raw,value=latest,enable={{is_default_branch}} 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to GitHub Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}      
+
+      # - name: Build and export to Docker
+      #   uses: docker/build-push-action@v6
+      #   with:
+      #     context: "{{defaultContext}}:docker"
+      #     load: true
+      #     tags: ${{ env.LATEST_TAG }}
+      #     file:
+      #       ./dockerfiles/mix3r/Dockerfile
+
+      # - name: Run unit tests I
+      #   run: |
+      #     docker run --rm -v ${{ github.workspace }}:/home ${{ env.LATEST_TAG }} py.test -v tests
+      
+      # - name: Run unit tests II
+      #   run: |
+      #     pip install -r test-requirements.txt
+      #     py.test -v tests
+  
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: "{{defaultContext}}"
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          file:
+            ./docker/Dockerfile
+          platforms: linux/amd64
+
+  build-apptainer-container:
+    needs: docker
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    name: Build Apptainer Container
+    steps:
+      - name: Check out code for the container builds
+        uses: actions/checkout@v4
+      - name: Setup Apptainer
+        uses: eWaterCycle/setup-apptainer@v2
+        with:
+          apptainer-version: 1.3.4
+      - name: Docker meta 
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ghcr.io/${{ github.repository_owner }}/mix3r            
+          tags: |
+            type=schedule
+            type=ref,event=branch
+            type=ref,event=pr
+            type=pep440,pattern={{version}}
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha
+            type=raw,value=latest,enable={{is_default_branch}} 
+      - name: Build and push Apptainer container
+        run: |
+          tags="${{ steps.meta.outputs.tags }}"
+          csv_tags=$(printf "%s\n" "$tags" | awk -F: 'NR==1{printf "%s,", $0; next} {printf "%s,", $NF}' | sed 's/,$//')
+          IFS= read -r first_tag <<EOF
+          $tags
+          EOF
+          push_tags="$(printf $csv_tags | sed -e "s/mix3r/mix3r_sif/g")"
+          echo ${{ secrets.GITHUB_TOKEN }} | oras login --username ${{ github.repository_owner }} --password-stdin ghcr.io
+          apptainer build -F --build-arg mix3r_image="$first_tag" mix3r.sif apptainer/mix3r.def
+          oras push "$push_tags" mix3r.sif
+          rm mix3r.sif
+        shell: sh

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,16 @@
+name: reviewdog
+
+on: [push, pull_request]
+
+jobs:
+  hadolint:
+    name: runner / hadolint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+      - name: hadolint
+        uses: reviewdog/action-hadolint@v1
+        with:
+          reporter: github-pr-review # Default is github-pr-check
+          fail_on_error: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,41 @@
+# Changelog
+All notable changes to the mix3r project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- additions goes here
+
+### Updated
+
+- updates goes here
+
+### Fixed
+
+- fixes goes here
+
+### Removed
+
+- removals goes here
+
+## [MAJOR.MINOR.PATCH] - YYYY-MM-DD
+
+### Added
+
+- additions goes here
+
+### Updated
+
+- updates goes here
+
+### Fixed
+
+- fixes goes here
+
+### Removed
+
+- removals goes here

--- a/README.md
+++ b/README.md
@@ -1,8 +1,42 @@
 # MIX3R
 
-## Create cluster environment with [micromamba](https://mamba.readthedocs.io/en/latest/user_guide/micromamba.html)
+This repository contains the source code for the trivariate mixer method to disentangle the genetic overlap between three phenotypes using summary statistics from genome-wide association studies (GWAS).
 
-The procedure should work on most of Linux distributions (but not on Mac).
+If you find this code useful, please cite the paper:
+
+    Dissecting the genetic overlap between three complex phenotypes with trivariate MiXeR
+    Alexey A. Shadrin, Guy Hindley, Espen Hagen, Nadine Parker, Markos Tesfaye, Piotr Jaholkowski, Zillur Rahman, Gleda Kutrolli, Vera Fominykh, Srdjan Djurovic, Olav B. Smeland, Kevin S. O’Connell, Dennis van der Meer, Oleksandr Frei, Ole A. Andreassen, Anders M. Dale
+    medRxiv 2024.02.23.24303236; doi: https://doi.org/10.1101/2024.02.23.24303236
+
+Bibtex:
+
+```bibtex
+@article {Shadrin2024.02.23.24303236,
+	author = {Shadrin, Alexey A. and Hindley, Guy and Hagen, Espen and Parker, Nadine and Tesfaye, Markos and Jaholkowski, Piotr and Rahman, Zillur and Kutrolli, Gleda and Fominykh, Vera and Djurovic, Srdjan and Smeland, Olav B. and O{\textquoteright}Connell, Kevin S. and van der Meer, Dennis and Frei, Oleksandr and Andreassen, Ole A. and Dale, Anders M.},
+	title = {Dissecting the genetic overlap between three complex phenotypes with trivariate MiXeR},
+	elocation-id = {2024.02.23.24303236},
+	year = {2024},
+	doi = {10.1101/2024.02.23.24303236},
+	publisher = {Cold Spring Harbor Laboratory Press},
+	abstract = {Comorbidities are an increasing global health challenge. Accumulating evidence suggests overlapping genetic architectures underlying comorbid complex human traits and disorders. The bivariate causal mixture model (MiXeR) can quantify the polygenic overlap between complex phenotypes beyond global genetic correlation. Still, the pattern of genetic overlap between three distinct phenotypes, which is important to better characterize multimorbidities, has previously not been possible to quantify. Here, we present and validate the trivariate MiXeR tool, which disentangles the pattern of genetic overlap between three phenotypes using summary statistics from genome-wide association studies (GWAS). Our simulations show that the trivariate MiXeR can reliably reconstruct different patterns of genetic overlap. We further demonstrate how the tool can be used to estimate the proportions of genetic overlap between three phenotypes using real GWAS data, providing examples of complex patterns of genetic overlap between diverse human traits and diseases that could not be deduced from bivariate analyses. This contributes to a better understanding of the etiology of complex phenotypes and the nature of their relationship, which may aid in dissecting comorbidity patterns and their biological underpinnings.Availability and implementation The trivariate MiXeR tool and auxiliary scripts, including source code, documentation and examples of use are available at https://github.com/precimed/mix3rCompeting Interest StatementSrdjan Djurovic has received speaker{\textquoteright}s Honoria from Lundbeck. Anders M. Dale is a Founder of and holds equity in CorTechs Labs, Inc, and serves on its Scientific Advisory Board. He is also a member of the Scientific Advisory Board of Human Longevity, Inc. (HLI), and the Mohn Medical Imaging and Visualization Centre in Bergen, Norway. He receives funding through a research agreement with General Electric Healthcare (GEHC). The terms of these arrangements have been reviewed and approved by the University of California, San Diego in accordance with its conflict-of-interest policies. Ole A. Andreassen has received speaker fees from Lundbeck, Janssen, Otsuka, and Sunovion and is a consultant to Cortechs.ai and Precision Health AS.Funding StatementThis work was supported by the Research Council of Norway (grants: 223273, 326813, 273291, 273446, 334920, 324499, 324252, 223273, 300309 and 248778). The European Economic Area and Norway Grants (grants: EEA-RO-NO-2018-0535 and EEA-RO-NO-2018-0573). European Union{\textquoteright}s Horizon 2020 Research and Innovation Programme (grants: 847776, 801133 and 964874). National Institutes of Health: U24DA041123, U24DA055330, 5R01MH124839-02 and R01MH123724-01. South-Eastern Norway Regional Health Authority (grant 2022073). KG Jebsen Stiftelsen, The South-East Norway Regional Health Authority (grant 2022-087).Author DeclarationsI confirm all relevant ethical guidelines have been followed, and any necessary IRB and/or ethics committee approvals have been obtained.YesThe details of the IRB/oversight body that provided approval or exemption for the research described are given below:The individual-level genotyping data for the current study were obtained from UK Biobank under accession number 27412. All researchers who wish to access this resource must register with UK Biobank by completing the registration form in the Access Management System. GWAS summary statistics data used in this study are publicly available and corresponding links are provided in the manuscript.I confirm that all necessary patient/participant consent has been obtained and the appropriate institutional forms have been archived, and that any patient/participant/sample identifiers included were not known to anyone (e.g., hospital staff, patients or participants themselves) outside the research group so cannot be used to identify individuals.YesI understand that all clinical trials and any other prospective interventional studies must be registered with an ICMJE-approved registry, such as ClinicalTrials.gov. I confirm that any such study reported in the manuscript has been registered and the trial registration ID is provided (note: if posting a prospective study registered retrospectively, please provide a statement in the trial ID field explaining why the study was not registered in advance).YesI have followed all appropriate research reporting guidelines, such as any relevant EQUATOR Network research reporting checklist(s) and other pertinent material, if applicable.YesAll data produced in the present work are contained in the manuscript. https://github.com/precimed/mix3r},
+	URL = {https://www.medrxiv.org/content/early/2024/02/27/2024.02.23.24303236},
+	eprint = {https://www.medrxiv.org/content/early/2024/02/27/2024.02.23.24303236.full.pdf},
+	journal = {medRxiv}
+}
+```
+
+## Installation and set up
+
+To obtain the source code, clone the repository using [Git](https://git-scm.com/):
+
+```bash
+<path/to/repositories>
+git clone https://www.github.com/precimed/mix3r
+```
+
+### Create cluster environment with [micromamba](https://mamba.readthedocs.io/en/latest/user_guide/micromamba.html)
+
+The procedure should work on most of Linux distributions (but not on Macs with ARM-based chipsets - M1, M2, M3, etc.).
 
 1. Create a folder, download the latest version of micromamba, configure and [install](https://mamba.readthedocs.io/en/latest/installation.html):
 
@@ -59,7 +93,7 @@ source mix3r/bin/activate
 conda-unpack
 ```
 
-### To run on TSD
+#### To run on TSD
 
 1. Prepare config files (you may use `config_scz_adhd_mig_aug22_1.json` as template) for multiple (e.g. 16) runs with different variant subsets. You may do it by changing `"rand_prune_seed"` parameter in the config file, e.g. set `"rand_prune_seed" : i` for the i-th run (also don't forget to use different output files for all runs, e.g. for the i-th run set `"out" : "my_analysis_run_i.json"`).
 2. Submit jobs for all configs to cluster:
@@ -89,15 +123,15 @@ Rscript make_euler.r my_analysis_all_runs.parameters.csv my_analysis.euler.png "
 
 Where the first argument is a path to the file with model parameters produced with `extract_p.py` script, the second argument is output file name and the last three arguments are trait labels to be used in the Euler diagram.
 
-## Containers
+### Containers
 
-### Build status
+#### Build status
 
 [![Dockerfile lint](https://github.com/precimed/mix3r/actions/workflows/docker.yml/badge.svg)](https://github.com/precimed/mix3r/actions/workflows/docker.yml)
 [![Container build](https://github.com/precimed/mix3r/actions/workflows/container_build.yml/badge.svg)](https://github.com/precimed/mix3r/actions/workflows/container_build.yml)
 [![Container build push](https://github.com/precimed/mix3r/actions/workflows/container_build_push.yml/badge.svg)](https://github.com/precimed/mix3r/actions/workflows/container_build_push.yml)
 
-### Dependencies on host system
+#### Dependencies on host system
 
 In order to set up these resource, some software may be required
 
@@ -106,12 +140,12 @@ In order to set up these resource, some software may be required
 - [Git LFS](https://git-lfs.com)
 - [ORAS CLI](https://oras.land)
 
-### Docker
+#### Docker
 
 [Docker](https://www.docker.com/) is a platform for developing, shipping, and running applications in containers.
 It allows you to package your application and all its dependencies into a single image that can be run on any machine.
 
-#### Fetch from GitHub Container Registry
+##### Fetch from GitHub Container Registry
 
 Docker containers with Mix3r are available on GitHub Container Registry. To pull the image, run the following command:
 
@@ -121,7 +155,7 @@ docker pull ghcr.io/precimed/mix3r:<tag>
 
 where `<tag>` is the version of the image you want to pull from the [GitHub Container Registry](https://github.com/precimed/mix3r/pkgs/container/mix3r). The latest version is tagged as `latest`.
 
-#### Build locally on host
+##### Build locally on host
 
 To build the image locally, you need to have Docker installed on your machine. Then you can run the following command in the root directory of the repository:
 
@@ -131,7 +165,7 @@ To build the image locally, you need to have Docker installed on your machine. T
 
 It will be tagged `latest` by default.
 
-#### Running the container
+##### Running the container
 
 You can also run the container with a command
 
@@ -145,11 +179,11 @@ For interactive sessions (e.g., `bash`, `ipython`, `jupyter`), you can run the c
     docker run -it --rm ghcr.io/precimed/mix3r:latest bash
 ```
 
-### Singularity/Apptainer
+#### Singularity/Apptainer
 
 [Singularity](https://sylabs.io/singularity/) and [Apptainer](https://apptainer.org) are container platforms that allow you to run containers on HPC systems.
 
-#### Fetch from GitHub Container Registry
+##### Fetch from GitHub Container Registry
 
 To obtain updated versions of the Singularity Image Format (.sif) container file `, issue
 
@@ -165,7 +199,7 @@ where `<tag>` corresponds to a tag listed under [packages](https://github.com/pr
 such as `latest`, `main`, or `sha_<GIT SHA>`. 
 The `oras pull` statement pulls the `mix3r.sif` file from [ghcr.io](https://github.com/precimed/mix3r/pkgs/container/mix3r_sif) using the [ORAS](https://oras.land) registry, without the need to build the container locally.
 
-#### Running the container
+##### Running the container
 
 The mix3r container can be run with the following command(s):
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-### Create cluster environment with [micromamba](https://mamba.readthedocs.io/en/latest/user_guide/micromamba.html)
+# MIX3R
+
+## Create cluster environment with [micromamba](https://mamba.readthedocs.io/en/latest/user_guide/micromamba.html)
 
 The procedure should work on most of Linux distributions (but not on Mac).
 
@@ -17,7 +19,7 @@ micromamba create -n mix3r \
     conda-pack=0.8.0 \
     numpy=2.0.2 \
     scipy=1.14.1 \
-    numba=0.6.0 \
+    numba=0.60.0 \
     cuda-nvcc cuda-nvrtc "cuda-version>=12.0,<=12.4" \
     pandas=2.2.3 \
     matplotlib-base=3.9.2 \
@@ -35,7 +37,13 @@ micromamba create -n mix3r \
 ```
 This assumes that you have NVIDIA driver supporting CUDA toolkit version 12. If your driver is for CUDA 11, you have to install CUDA `cudatoolkit` instead of `cuda-nvcc` and `cuda-nvrtc`, see [numba's documentation](https://numba.readthedocs.io/en/stable/cuda/overview.html#software) for more details. For compatibility of minor versions (i.e. 12.4 vs 12.6) it might be better to set the upper bound of cuda-version (which is equal to 12.4 in the code above, and defines the version of CUDA toolkit which will be installed) to the version supported by the NVIDIA driver. CUDA toolkit version supported by the installed NVIDIA driver can be checked with `nvidia-smi` command (shown in the top row of the output table, after the driver version).
 
-2. Activate and pack the environment:
+Alternatively, create the environment with `environment.yml` file:
+
+```bash
+micromamba env create -f environment.yml
+```
+
+1. Activate and pack the environment:
 
 ```
 micromamba activate mix3r
@@ -80,3 +88,97 @@ Rscript make_euler.r my_analysis_all_runs.parameters.csv my_analysis.euler.png "
 ```
 
 Where the first argument is a path to the file with model parameters produced with `extract_p.py` script, the second argument is output file name and the last three arguments are trait labels to be used in the Euler diagram.
+
+## Containers
+
+### Build status
+
+[![Dockerfile lint](https://github.com/precimed/mix3r/actions/workflows/docker.yml/badge.svg)](https://github.com/precimed/mix3r/actions/workflows/docker.yml)
+[![Container build](https://github.com/precimed/mix3r/actions/workflows/container_build.yml/badge.svg)](https://github.com/precimed/mix3r/actions/workflows/container_build.yml)
+[![Container build push](https://github.com/precimed/mix3r/actions/workflows/container_build_push.yml/badge.svg)](https://github.com/precimed/mix3r/actions/workflows/container_build_push.yml)
+
+### Dependencies on host system
+
+In order to set up these resource, some software may be required
+
+- [Singularity/SingularityCE](https://sylabs.io/singularity/) or [Apptainer](https://apptainer.org)
+- [Git](https://git-scm.com/)
+- [Git LFS](https://git-lfs.com)
+- [ORAS CLI](https://oras.land)
+
+### Docker
+
+[Docker](https://www.docker.com/) is a platform for developing, shipping, and running applications in containers.
+It allows you to package your application and all its dependencies into a single image that can be run on any machine.
+
+#### Fetch from GitHub Container Registry
+
+Docker containers with Mix3r are available on GitHub Container Registry. To pull the image, run the following command:
+
+```bash
+docker pull ghcr.io/precimed/mix3r:<tag>
+```
+
+where `<tag>` is the version of the image you want to pull from the [GitHub Container Registry](https://github.com/precimed/mix3r/pkgs/container/mix3r). The latest version is tagged as `latest`.
+
+#### Build locally on host
+
+To build the image locally, you need to have Docker installed on your machine. Then you can run the following command in the root directory of the repository:
+
+```bash
+    docker build --platform=linux/amd64 -t ghcr.io/precimed/mix3r -f docker/Dockerfile .
+```
+
+It will be tagged `latest` by default.
+
+#### Running the container
+
+You can also run the container with a command
+
+```bash
+    docker run ghcr.io/precimed/mix3r:latest <command>  # Available commands are: mix3r_int_weights, extract_p, make_template, make_euler, bash, python, ipython, jupyter
+```
+
+For interactive sessions (e.g., `bash`, `ipython`, `jupyter`), you can run the container with the following command:
+
+```bash
+    docker run -it --rm ghcr.io/precimed/mix3r:latest bash
+```
+
+### Singularity/Apptainer
+
+[Singularity](https://sylabs.io/singularity/) and [Apptainer](https://apptainer.org) are container platforms that allow you to run containers on HPC systems.
+
+#### Fetch from GitHub Container Registry
+
+To obtain updated versions of the Singularity Image Format (.sif) container file `, issue
+
+```bash
+cd <path/to/>/mix3r/apptainer
+mv mix3r.sif mix3r.sif.old  # optional, just rename the old(er) file if present
+apptainer build -F --build-arg mix3r_image="docker://ghcr.io/precimed/mix3r:<tag>" mix3r.sif mix3r.def  # or
+singularity build -F --build-arg mix3r_image="docker://ghcr.io/precimed/mix3r:<tag>" mix3r.sif mix3r.def # or 
+oras pull ghcr.io/precimed/mix3r_sif:<tag> # recommended
+```
+
+where `<tag>` corresponds to a tag listed under [packages](https://github.com/precimed/mix3r/pkgs/container/mix3r_sif),
+such as `latest`, `main`, or `sha_<GIT SHA>`. 
+The `oras pull` statement pulls the `mix3r.sif` file from [ghcr.io](https://github.com/precimed/mix3r/pkgs/container/mix3r_sif) using the [ORAS](https://oras.land) registry, without the need to build the container locally.
+
+#### Running the container
+
+The mix3r container can be run with the following command(s):
+
+```bash
+export ROOT_DIR=<path/to/>/mix3r
+export APPTAINER_BIND='/<path/to/data>:<path/to/data>:ro'
+export SIF=$ROOT_DIR/apptainer/mix3r.sif
+export CONFIG=$ROOT_DIR/examples/config.json
+export MIX3R="apptainer run --nv ${SIF}"  # --nv is for CUDA/GPU support
+
+$MIX3R mix3r_int_weights --config $CONFIG
+$MIX3R extract_p --input my_analysis_run_*.json --out my_analysis_all_runs
+$MIX3R make_euler my_analysis_all_runs.parameters.csv my_analysis.euler.png "Trait 1" "Trait 2" "Trait 3"
+```
+
+There are also other commands available in the container, such as `make_template`, `bash`, `python`, `ipython`, and `jupyter`.

--- a/apptainer/mix3r.def
+++ b/apptainer/mix3r.def
@@ -1,0 +1,9 @@
+Bootstrap: docker
+From: {{ mix3r_image }}
+
+%post
+
+%environment
+
+%runscript
+    exec entrypoint.sh "$@"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,20 @@
+FROM mambaorg/micromamba:2.0-cuda12.4.1-ubuntu22.04
+
+WORKDIR /tmp/install
+COPY ../environment.yml .
+RUN micromamba env update --name base --file environment.yml && \
+    micromamba clean --all --yes
+
+WORKDIR /tmp
+RUN rm -rf install
+
+WORKDIR /scripts
+COPY ../mix3r_int_weights.py .
+COPY ../extract_p.py .
+COPY ../make_euler.r .
+COPY ../make_template.py .
+
+WORKDIR /
+
+COPY docker/entrypoint.sh /usr/local/bin/entrypoint.sh
+ENTRYPOINT ["entrypoint.sh"]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+set -e
+
+case "$1" in
+  "mix3r_int_weights")
+    shift
+    /opt/conda/bin/python /scripts/mix3r_int_weights.py "$@"
+    ;;
+  "extract_p")
+    shift
+    /opt/conda/bin/python /scripts/extract_p.py "$@"
+    ;;
+  "make_template")
+    shift
+    /opt/conda/bin/python /scripts/make_template.py "$@"
+    ;;
+  "make_euler")
+    shift
+    /opt/conda/bin/Rscript /scripts/make_euler.r "$@"
+    ;;
+  "python")
+    shift
+    /opt/conda/bin/python "$@"
+    ;;
+  "ipython")
+    shift
+    /opt/conda/bin/ipython "$@"
+    ;;
+  "jupyter")
+    shift
+    /opt/conda/bin/jupyter "$@"
+    ;;
+  "bash")
+    shift
+    /usr/bin/bash "$@"
+    ;;
+  *)
+    echo "Invalid command. Available commands are: mix3r_int_weights, extract_p, make_template, make_euler, python, ipython, jypyter, bash"
+    exit 1
+    ;;
+esac

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,26 @@
+
+
+name: mix3r
+channels:
+  - conda-forge
+  - numba
+  - rapidsai
+dependencies:
+  - python=3.12
+  - conda-pack=0.8.0
+  - numpy=2.0.2
+  - scipy=1.14.1
+  - numba=0.60.0
+  - cuda-nvcc=12.4.131
+  - cuda-nvrtc=12.4.127
+  - pandas=2.2.3
+  - matplotlib-base=3.9.2
+  - ipython=8.28.0
+  - notebook=7.2.2
+  - r=4.4
+  - r-essentials=4.4
+  - r-irkernel=1.3.2
+  - r-eulerr=7.0.2
+  - numba::numba=0.60.0
+  - numba::icc_rt=2020.2
+  - rapidsai::pynvjitlink=0.3.0


### PR DESCRIPTION
Fixes #2, adding Dockerfile and GitHub action files to automatize container builds and pushes to [GHCR.io](https://ghcr.io). 

Docker/SIF builds should only be pushed on pushed tag events on `main` branch:
```bash
git pull
git tag -a v0.1.0 -m v0.1.0
git push --tags
```
Also adds a CHANGELOG file (for future semantic versioning). 

Tested the corresponding sngularity build with files using the top-level config JSON file in this repo with a subset of chromosomes and a reduced number of randomly pruned SNPs, and it appears to work as intended.   